### PR TITLE
Fix #2.

### DIFF
--- a/docs/poly.py
+++ b/docs/poly.py
@@ -35,7 +35,7 @@ MOCK_DATA = {
         GitRef("dev", "", "", GitRefType.BRANCH, datetime.fromtimestamp(4)),
         GitRef("some-feature", "", "", GitRefType.BRANCH, datetime.fromtimestamp(5)),
     ],
-    "current": GitRef("local", "", "", GitRefType.BRANCH, datetime.fromtimestamp(6)),
+    "current": GitRef("local", "", "", GitRefType.TAG, datetime.fromtimestamp(6)),
 }
 MOCK = False
 


### PR DESCRIPTION
Before this commit when building locally using mock data,
the latest tag would be used as a reqirect from the root URL.
Now the local build is redirected to instead.