### PR TITLE
[docs] List a few alternative projects

### DIFF
--- a/docs/sphinx/alternatives.rst
+++ b/docs/sphinx/alternatives.rst
@@ -1,0 +1,8 @@
+------------
+Alternatives
+------------
+
+- `sphinx-multiversion <https://github.com/Holzhaus/sphinx-multiversion>`_ (unmaintained)
+- `sphinxcontrib-versioning <https://github.com/sphinx-contrib/sphinxcontrib-versioning>`_ (unmaintained)
+- `sphinx_simpleversion <https://github.com/isaksamsten/sphinx_simpleversion>`_
+- `sphinx_versioning <https://github.com/Yihengxiong6/sphinx_versioning>`_

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -18,6 +18,7 @@ Table of Contents
 
     guide/installation
     guide/getting-started
+    alternatives
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
This adds a new page to the documentation that lists a few alternative tools that serve the same purpose as `sphinx-polyversion`.

* docs/sphinx/alternatives.rst: bullet list

* docs/sphinx/index.rst: Add a link to the new page.