### PR TITLE
[docs] Branch to get started on

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,6 +69,7 @@
 - [ ] Extensive Documentation
   - [ ] User guide
     - [ ] Use different setups depending on the version
+    - [ ] Updating docs from old versions using cherry-pick
   - [ ] Subclassing guide
   - [ ] Reference
     - [ ] Command line syntax

--- a/docs/sphinx/guide/getting-started.rst
+++ b/docs/sphinx/guide/getting-started.rst
@@ -9,6 +9,11 @@ This guide assumes that you installed `sphinx-polyversion` into the development
 environment of your project and have written some documentation that builds
 with `sphinx-build`.
 
+For this tool it doesn't matter which branch you are working on as it will
+query the whole git repository for branches and tags to build documentation for.
+However you will need to fetch all the references that should be visible to the tool.
+However the tool will always use the configuration currently checked out.
+
 .. TODO: link sphinx docs / sphinx build
 
 Configuring `sphinx-polyversion`


### PR DESCRIPTION
This adds a paragraph to the getting started guide to clarify that it
does not matter which branch you configure the tool on.

* docs/sphinx/guide/getting-started.rst: Add paragraph regarding current branch