### PR TITLE
Allow nested templates for root

### DIFF
--- a/sphinx_polyversion/driver.py
+++ b/sphinx_polyversion/driver.py
@@ -678,4 +678,5 @@ class DefaultDriver(Driver[JRT, ENV], Generic[JRT, ENV, S]):
                 template = env.get_template(template_path_str)
                 rendered = template.render(context)
                 output_path = self.output_dir / template_path_str
+                output_path.parent.mkdir(parents=True, exist_ok=True)
                 output_path.write_text(rendered)


### PR DESCRIPTION
First of all, thanks for building this tool. I just used it to add multi-version docs to an existing project, and the modular design made it easy to extend/patch the behavior to suit my needs. Some things might be valuable for others as well. As the work is already done, I will directly open a PR, but I can add corresponding issues as well. Please merge/reject them as you see fit for the scope of this project.

I encountered a `FileNotFoundError` when the templates directory for the root has a nested structure. This is because the directory of the target files might not exist yet. Adding the corresponding `mkdir` call to the path resolves the issue.