### PR TITLE
Add option to use temporary venv to Pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ ENVIRONMENT = {
     None: Poetry.factory(args="--sync".split()),  # first version
     "v1.5.7": Poetry.factory(args="--only sphinx --sync".split()),
     "v1.8.2": Poetry.factory(args="--only dev --sync".split(), env={"MY_VAR": "value"}),
+    # use a pre-existing environment at the location ./.venv
     "v3.0.0": Pip.factory(venv=Path(".venv"), args="-e . -r requirements.txt".split()),
+    # dynamically create an environment in the temporary build directory
+    "v4.*.*": Pip.factory(venv=Path(".venv"), args="-e . -r requirements.txt".split(), creator=VenvWrapper(), temporary=True),
 }
 
 # ...

--- a/sphinx_polyversion/pyvenv.py
+++ b/sphinx_polyversion/pyvenv.py
@@ -412,6 +412,10 @@ class Pip(VirtualPythonEnvironment):
         The cmd arguments to pass to `pip install`.
     creator : Callable[[Path], Any] | None, optional
         A callable for creating the venv, by default None
+    temporary   : bool, optional
+        A flag to specify whether the environment should be created in the
+        temporary directory, by default False. If this is True, `creator`
+        must not be None.
     env  : dict[str, str], optional
         A dictionary of environment variables which are overridden in the
         virtual environment, by default None
@@ -426,6 +430,7 @@ class Pip(VirtualPythonEnvironment):
         *,
         args: Iterable[str],
         creator: Callable[[Path], Any] | None = None,
+        temporary: bool = False,
         env: dict[str, str] | None = None,
     ):
         """
@@ -443,13 +448,31 @@ class Pip(VirtualPythonEnvironment):
             The cmd arguments to pass to `pip install`.
         creator : Callable[[Path], Any], optional
             A callable for creating the venv, by default None
+        temporary   : bool, optional
+            A flag to specify whether the environment should be created in the
+            temporary directory, by default False. If this is True, `creator`
+            must not be None.
         env  : dict[str, str], optional
             A dictionary of environment variables which are overridden in the
             virtual environment, by default None
 
+        Raises
+        ------
+        ValueError
+            If `temporary` is enabled, but no valid creator is provided.
+
         """
-        super().__init__(path, name, venv, creator=creator, env=env)
         self.args = args
+        if temporary:
+            if creator is None:
+                raise ValueError(
+                    "Cannot create temporary virtual environment when creator is None."
+                    "Please set creator to enable temporary virtual environments, or "
+                    "set temporary to False to use a pre-existing local environment "
+                    f"at path {venv}."
+                )
+            venv = path / venv
+        super().__init__(path, name, venv, creator=creator, env=env)
 
     async def __aenter__(self) -> Self:
         """

--- a/sphinx_polyversion/pyvenv.py
+++ b/sphinx_polyversion/pyvenv.py
@@ -459,17 +459,17 @@ class Pip(VirtualPythonEnvironment):
         Raises
         ------
         ValueError
-            If `temporary` is enabled, but no valid creator is provided.
+            If `temporary` is enabled but no valid creator is provided.
 
         """
         self.args = args
         if temporary:
             if creator is None:
                 raise ValueError(
-                    "Cannot create temporary virtual environment when creator is None."
+                    "Cannot create temporary virtual environment when creator is None.\n"
                     "Please set creator to enable temporary virtual environments, or "
                     "set temporary to False to use a pre-existing local environment "
-                    f"at path {venv}."
+                    f"at path '{venv}'."
                 )
             venv = path / venv
         super().__init__(path, name, venv, creator=creator, env=env)

--- a/sphinx_polyversion/pyvenv.py
+++ b/sphinx_polyversion/pyvenv.py
@@ -415,7 +415,7 @@ class Pip(VirtualPythonEnvironment):
     temporary   : bool, optional
         A flag to specify whether the environment should be created in the
         temporary directory, by default False. If this is True, `creator`
-        must not be None.
+        must not be None and `venv` will be treated relative to `path`.
     env  : dict[str, str], optional
         A dictionary of environment variables which are overridden in the
         virtual environment, by default None
@@ -451,7 +451,7 @@ class Pip(VirtualPythonEnvironment):
         temporary   : bool, optional
             A flag to specify whether the environment should be created in the
             temporary directory, by default False. If this is True, `creator`
-            must not be None.
+            must not be None and `venv` will be treated relative to `path`.
         env  : dict[str, str], optional
             A dictionary of environment variables which are overridden in the
             virtual environment, by default None
@@ -462,7 +462,6 @@ class Pip(VirtualPythonEnvironment):
             If `temporary` is enabled but no valid creator is provided.
 
         """
-        self.args = args
         if temporary:
             if creator is None:
                 raise ValueError(
@@ -473,6 +472,7 @@ class Pip(VirtualPythonEnvironment):
                 )
             venv = path / venv
         super().__init__(path, name, venv, creator=creator, env=env)
+        self.args = args
 
     async def __aenter__(self) -> Self:
         """

--- a/tests/test_pyvenv.py
+++ b/tests/test_pyvenv.py
@@ -128,6 +128,122 @@ class TestPip:
     """Test the `Pip` class."""
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio()
+    async def test_creation_with_venv(self, tmp_path: Path):
+        """Test the `create_venv` method with a `VenvWrapper`."""
+        location = tmp_path / "venv"
+        env = Pip(
+            tmp_path,
+            "main",
+            location,
+            args=["tomli"],
+            creator=VenvWrapper(),
+            temporary=False,
+        )
+
+        await env.create_venv()
+        assert (location / "bin" / "python").exists()
+
+    @pytest.mark.asyncio()
+    async def test_creation_without_creator(self, tmp_path: Path):
+        """Test the `create_venv` method without any creator."""
+        location = tmp_path / "venv"
+        env = Pip(tmp_path, "main", location, args=["tomli"], temporary=False)
+
+        await env.create_venv()
+        assert not (location / "bin" / "python").exists()
+
+    @pytest.mark.asyncio()
+    async def test_run_without_creator(self, tmp_path: Path):
+        """Test running a command in an existing venv."""
+        location = tmp_path / "venv"
+
+        # create env
+        await VenvWrapper([])(location)
+
+        async with Pip(
+            tmp_path, "main", location, args=["tomli"], temporary=False
+        ) as env:
+            out, err, rc = await env.run(
+                "python",
+                "-c",
+                "import sys; print(sys.prefix)",
+                stdout=asyncio.subprocess.PIPE,
+            )
+            assert rc == 0
+            assert str(location) == out.strip()
+
+    @pytest.mark.asyncio()
+    async def test_run_with_creator(self, tmp_path: Path):
+        """Test running a command in a new venv."""
+        location = tmp_path / "venv"
+
+        async with Pip(
+            tmp_path,
+            "main",
+            location,
+            args=["tomli"],
+            creator=VenvWrapper(),
+            temporary=False,
+        ) as env:
+            out, err, rc = await env.run(
+                "python",
+                "-c",
+                "import sys; print(sys.prefix)",
+                stdout=asyncio.subprocess.PIPE,
+            )
+            assert rc == 0
+            assert str(location) == out.strip()
+
+    @pytest.mark.asyncio()
+    async def test_creation_with_venv_temporary(self, tmp_path: Path):
+        """Test the `create_venv` method with a `VenvWrapper`."""
+        location = "tmpvenv"
+        env = Pip(
+            tmp_path,
+            "main",
+            location,
+            args=["tomli"],
+            creator=VenvWrapper(),
+            temporary=True,
+        )
+
+        await env.create_venv()
+        assert (tmp_path / location / "bin" / "python").exists()
+
+    @pytest.mark.asyncio()
+    async def test_creation_without_creator_temporary(self, tmp_path: Path):
+        """Test the `create_venv` method without any creator."""
+        location = "tmpvenv"
+        with pytest.raises(
+            ValueError,
+            match="Cannot create temporary virtual environment when creator is None",
+        ):
+            Pip(tmp_path, "main", location, args=["tomli"], temporary=True)
+
+    @pytest.mark.asyncio()
+    async def test_run_with_creator_temporary(self, tmp_path: Path):
+        """Test running a command in a new venv."""
+        location = "tmpvenv"
+
+        async with Pip(
+            tmp_path,
+            "main",
+            location,
+            args=["tomli"],
+            creator=VenvWrapper(),
+            temporary=True,
+        ) as env:
+            out, err, rc = await env.run(
+                "python",
+                "-c",
+                "import sys; print(sys.prefix)",
+                stdout=asyncio.subprocess.PIPE,
+            )
+            assert rc == 0
+            assert str(tmp_path / location) == out.strip()
+
+    @pytest.mark.asyncio()
     async def test_install_into_existing_venv(self, tmp_path: Path):
         """Test installing a package into an existing venv."""
         location = tmp_path / "venv"

--- a/tests/test_pyvenv.py
+++ b/tests/test_pyvenv.py
@@ -128,7 +128,7 @@ class TestPip:
     """Test the `Pip` class."""
 
     @pytest.mark.asyncio
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_creation_with_venv(self, tmp_path: Path):
         """Test the `create_venv` method with a `VenvWrapper`."""
         location = tmp_path / "venv"
@@ -144,7 +144,7 @@ class TestPip:
         await env.create_venv()
         assert (location / "bin" / "python").exists()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_creation_without_creator(self, tmp_path: Path):
         """Test the `create_venv` method without any creator."""
         location = tmp_path / "venv"
@@ -153,7 +153,7 @@ class TestPip:
         await env.create_venv()
         assert not (location / "bin" / "python").exists()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_run_without_creator(self, tmp_path: Path):
         """Test running a command in an existing venv."""
         location = tmp_path / "venv"
@@ -173,7 +173,7 @@ class TestPip:
             assert rc == 0
             assert str(location) == out.strip()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_run_with_creator(self, tmp_path: Path):
         """Test running a command in a new venv."""
         location = tmp_path / "venv"
@@ -195,7 +195,7 @@ class TestPip:
             assert rc == 0
             assert str(location) == out.strip()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_creation_with_venv_temporary(self, tmp_path: Path):
         """Test the `create_venv` method with a `VenvWrapper`."""
         location = "tmpvenv"
@@ -211,7 +211,7 @@ class TestPip:
         await env.create_venv()
         assert (tmp_path / location / "bin" / "python").exists()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_creation_without_creator_temporary(self, tmp_path: Path):
         """Test the `create_venv` method without any creator."""
         location = "tmpvenv"
@@ -221,7 +221,7 @@ class TestPip:
         ):
             Pip(tmp_path, "main", location, args=["tomli"], temporary=True)
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_run_with_creator_temporary(self, tmp_path: Path):
         """Test running a command in a new venv."""
         location = "tmpvenv"
@@ -243,7 +243,7 @@ class TestPip:
             assert rc == 0
             assert str(tmp_path / location) == out.strip()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_install_into_existing_venv(self, tmp_path: Path):
         """Test installing a package into an existing venv."""
         location = tmp_path / "venv"


### PR DESCRIPTION
Closes  #17.

Currently, the `Pip` class cannot be used to create virtual environments in the temporary build directory. This PR fixes this by introducing the keyword argument `temporary`, which can be set to `False` for local paths and `True` for paths in the temporary directory.

As the specification of the tests indicate that using local virtual environments without a creator is a valid use case, this behavior is still allowed. To avoid breaking changes, the default is set to `temporary=False`, to be consistent with the existing behavior. As this is inconsistent with the way `Poetry` works, this might lead to confusion for people who think they are interchangeable. If a new major version is released and breaking changes are considered acceptable, changing the default of temporary would make the `Pip` behave more similar to `Poetry`.

As `Pip` is not mentioned in the quick-start guide, I only added a minimal example with a short explanation to the README. Let me know if more docs are required, and what form they should take.