### PR TITLE
Throw error when trying to activate non-existing venv

### DIFF
--- a/sphinx_polyversion/pyvenv.py
+++ b/sphinx_polyversion/pyvenv.py
@@ -175,7 +175,18 @@ class VirtualPythonEnvironment(Environment):
         dict[str, str]
             The dictionary that was passed with `env`.
 
+        Raises
+        ------
+        FileNotFoundError
+            If no environment is located at the location `venv`.
+
         """
+        if not self.venv.exists():
+            raise FileNotFoundError(
+                f"""There is no virtual environment at the path {self.venv}.
+                Please ensure that the path points to an existing virtual environment, or
+                supply a creator to automatically create the environment."""
+            )
         env["VIRTUAL_ENV"] = str(self.venv)
         env["PATH"] = str(self.venv / "bin") + ":" + env["PATH"]
         return env

--- a/tests/test_pyvenv.py
+++ b/tests/test_pyvenv.py
@@ -58,6 +58,20 @@ class TestVirtualPythonEnvionment:
         assert not (location / "bin" / "python").exists()
 
     @pytest.mark.asyncio()
+    async def test_run_without_creator_no_existing(self, tmp_path: Path):
+        """Test running a command without an existing venv and without creator."""
+        location = tmp_path / "novenv"
+
+        async with VirtualPythonEnvironment(tmp_path, "main", location) as env:
+            with pytest.raises(FileNotFoundError, match="There is no virtual"):
+                out, err, rc = await env.run(
+                    "python",
+                    "-c",
+                    "import sys; print(sys.prefix)",
+                    stdout=asyncio.subprocess.PIPE,
+                )
+
+    @pytest.mark.asyncio()
     async def test_run_without_creator(self, tmp_path: Path):
         """Test running a command in an existing venv."""
         location = tmp_path / "venv"


### PR DESCRIPTION
Closes #21. Throw an error when the path `VirtualPythonEnvironment.venv` does not exist when calling `VirtualPythonEnvironment.activate`.