### PR TITLE
Fix passing a dict for `builder`.

### DIFF
--- a/sphinx_polyversion/driver.py
+++ b/sphinx_polyversion/driver.py
@@ -508,7 +508,7 @@ class DefaultDriver(Driver[JRT, ENV], Generic[JRT, ENV, S]):
         self.encoder = encoder or GLOBAL_ENCODER
         self.root_data_factory = root_data_factory
 
-        if isinstance(builder, dict) or (isinstance(env, dict) and not selector):
+        if (isinstance(builder, dict) or isinstance(env, dict)) and not selector:
             raise ValueError(
                 "Must provide selector if a mapping is passed for `builder` or `env`."
             )


### PR DESCRIPTION
Do to a unintended operator precedence, ruff
later added brackets where they do not belong.
This moves them and fixes the bug where
passing a dictionary to the `builder` keyword
of `DefaultDriver` wasn't possible.
Fixes #27.

* sphinx_polyversion/driver.py (DefaultDriver): Fix.