### PR TITLE
Only copy files not ignored by git for local build

### DIFF
--- a/sphinx_polyversion/driver.py
+++ b/sphinx_polyversion/driver.py
@@ -342,7 +342,7 @@ class Driver(Generic[RT, ENV], metaclass=ABCMeta):
                     source = self.root / filename
                     target = path / filename
                     target.parent.mkdir(parents=True, exist_ok=True)
-                    if not target.exists():
+                    if source.exists() and not target.exists():
                         shutil.copy2(source, target, follow_symlinks=False)
             except CalledProcessError:
                 logger.warning(

--- a/sphinx_polyversion/driver.py
+++ b/sphinx_polyversion/driver.py
@@ -337,10 +337,9 @@ class Driver(Generic[RT, ENV], metaclass=ABCMeta):
             # copy source files
             logger.info("Copying source files (except for files ignored by git)...")
             try:
-                files = await get_unignored_files(self.root)
-                for filename in files:
-                    source = self.root / filename
-                    target = path / filename
+                async for file in get_unignored_files(self.root):
+                    source = self.root / file
+                    target = path / file
                     target.parent.mkdir(parents=True, exist_ok=True)
                     if source.exists() and not target.exists():
                         shutil.copy2(source, target, follow_symlinks=False)

--- a/sphinx_polyversion/git.py
+++ b/sphinx_polyversion/git.py
@@ -259,6 +259,34 @@ async def file_exists(repo: Path, ref: GitRef, file: PurePath) -> bool:
     return rc == 0
 
 
+async def get_unignored_files(directory: Path) -> list[Path]:
+    """
+    List all unignored files in the directory.
+
+    Parameters
+    ----------
+    directory : Path
+        Any directory in the repo.
+
+    Returns
+    -------
+    Path
+        The paths to all un-ignored files in the directory (recursive)
+
+    """
+    cmd = (
+        "git",
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+    )
+    process = await asyncio.create_subprocess_exec(*cmd, cwd=directory, stdout=PIPE)
+    out, err = await process.communicate()
+    files = out.decode().split("\n")
+    return [Path(path.strip()) for path in files]
+
+
 # -- VersionProvider API -----------------------------------------------------
 
 

--- a/sphinx_polyversion/git.py
+++ b/sphinx_polyversion/git.py
@@ -259,7 +259,7 @@ async def file_exists(repo: Path, ref: GitRef, file: PurePath) -> bool:
     return rc == 0
 
 
-async def get_unignored_files(directory: Path) -> list[Path]:
+async def get_unignored_files(directory: Path) -> AsyncGenerator[Path, None]:
     """
     List all unignored files in the directory.
 
@@ -270,7 +270,7 @@ async def get_unignored_files(directory: Path) -> list[Path]:
 
     Returns
     -------
-    Path
+    AsyncGenerator[Path, None]
         The paths to all un-ignored files in the directory (recursive)
 
     """
@@ -283,8 +283,8 @@ async def get_unignored_files(directory: Path) -> list[Path]:
     )
     process = await asyncio.create_subprocess_exec(*cmd, cwd=directory, stdout=PIPE)
     out, err = await process.communicate()
-    files = out.decode().split("\n")
-    return [Path(path.strip()) for path in files]
+    for line in out.decode().splitlines():
+        yield Path(line.strip())
 
 
 # -- VersionProvider API -----------------------------------------------------

--- a/sphinx_polyversion/vcs.py
+++ b/sphinx_polyversion/vcs.py
@@ -49,6 +49,20 @@ class VersionProvider(Protocol[RT]):
         """
 
     @abstractmethod
+    async def checkout_local(self, root: Path, dest: Path) -> None:
+        """
+        Create copy of the local working directory at the given path.
+
+        Parameters
+        ----------
+        root : Path
+            The root path of the project.
+        dest : Path
+            The destination to extract the revision to.
+
+        """
+
+    @abstractmethod
     async def retrieve(self, root: Path) -> Iterable[RT]:
         """
         List all build targets.


### PR DESCRIPTION
Closes #30.

Using `git ls-files --cached --others --exclude-standard`, we can obtain all files that are not ignored by git. This will also include files that are not checked in. We can use this list to only copy non-ignored files for local builds, which can significantly speed up the build process when large ignored files/directories are present in the working directory.

This PR tries to use the git command, and falls back to a full copy in case of errors.