### PR TITLE
branches and tags are swapped in guide

### DIFF
--- a/docs/sphinx/guide/getting-started.rst
+++ b/docs/sphinx/guide/getting-started.rst
@@ -301,7 +301,7 @@ to :code:`DefaultDriver`.
 
     def root_data(driver: DefaultDriver):
         revisions = driver.builds
-        tags, branches  = refs_by_type(revisions)
+        branches, tags  = refs_by_type(revisions)
         latest = max(tags or branches)
         return {"revisions": revisions, "latest": latest}
 


### PR DESCRIPTION
Also I want to point out that `max(tags)` doesn't work properly for me either - it thinks that v0.0.9 is newer than v0.0.10. I have a workaround for this but I don't think it's very Pythonic (I'm not a Python dev), so I'll let you figure out if there is a better way to solve that.

Workaround below:
```python
from packaging.version import parse as parse_version

branches, tags  = refs_by_type(revisions)
latest = tags[0]
latestVersion = parse_version(tags[0].name)
for tag in tags:
    newVersion = parse_version(tag.name)
    if newVersion > latestVersion:
        latestVersion = newVersion
        latest = tag
```