### PR TITLE
Docs: Introduce sphinx-codeautolink

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -44,6 +44,8 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
+    # in code blocks automatically link to the autodoc reference
+    "sphinx_codeautolink",
     # link references to source code
     "sphinx.ext.linkcode",
     # link shortcuts

--- a/docs/sphinx/guide/getting-started.rst
+++ b/docs/sphinx/guide/getting-started.rst
@@ -75,6 +75,8 @@ be overridden from the commandline before being used to build the documentation.
 This is a major feature of `sphinx-polyversion` which will be explained in this
 section and :ref:`further down this guide<Overriding config options>`.
 
+.. autolink-concat:: section
+
 .. code-block:: py
     :caption: `docs/poly.py` - imports and config variables
     :linenos:
@@ -204,6 +206,10 @@ though.
 
 .. TODO: link docs for data format
 
+.. autolink-preface::
+
+   from sphinx_polyversion.git import GitRef
+
 .. code-block:: py
     :caption: default data exposed to sphinx docs
 
@@ -290,7 +296,12 @@ know which tag represents the latest revision. First you have to implement
 :code:`root_data` (see below) and then pass :code:`root_data_factory=root_data`
 to :code:`DefaultDriver`.
 
+.. TODO mention that max sorts by creation date
 .. TODO link reference
+
+.. autolink-preface::
+
+   from sphinx_polyversion import *
 
 .. code-block:: py
     :caption: `docs/poly.py` - calculate and expose latest revision

--- a/poetry.lock
+++ b/poetry.lock
@@ -1148,6 +1148,24 @@ sphinx = ">=4.0"
 docs = ["furo", "ipython", "myst-parser", "sphinx-copybutton", "sphinx-inline-tabs"]
 
 [[package]]
+name = "sphinx-codeautolink"
+version = "0.17.4"
+description = "Automatic links from code examples to reference documentation."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "sphinx_codeautolink-0.17.4-py3-none-any.whl", hash = "sha256:602d94379c1a87141deedce66c17bc52a7f9c5f78a62b9c3ea94d103d6b32c21"},
+    {file = "sphinx_codeautolink-0.17.4.tar.gz", hash = "sha256:44afd4102a1f1517838822f3ddc09d89aade642bb04302d749bb48adc3f2057e"},
+]
+
+[package.dependencies]
+beautifulsoup4 = ">=4.8.1"
+sphinx = ">=3.2.0"
+
+[package.extras]
+ipython = ["ipython (!=8.7.0)"]
+
+[[package]]
 name = "sphinx-copybutton"
 version = "0.5.2"
 description = "Add a copy button to each of your code cells."
@@ -1660,4 +1678,4 @@ virtualenv = ["virtualenv"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "9e4be5e5bdb6f3cc24e0fa9b49844b3036945d5734a32496a205c909fec77d5d"
+content-hash = "0e801455b031d9fd254dd6856b2f991980c35b3bbf4b3f8dc6e2d0a9d75d99eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ sphinxext-opengraph              = { version = "^0.9.1", python = ">=3.9" }
 sphinx-autobuild                 = { version = "^2024.4.16", python = ">=3.9" }
 sphinx-design                    = { version = "^0.6", python = ">=3.9" }
 jinja2                           = { version = "^3.1.4", python = ">=3.9" }
+sphinx-codeautolink              = { version = "^0.17.4", python = ">=3.10" }
 
 
 [tool.black]


### PR DESCRIPTION
This extension will automatically link code
references inside code blocks to the autodoc
entries that are also part of the documentation.

* pyproject.toml : Add sphinx-codeautolink to `docs` group
* poetry.lock : Update using `poetry lock`
* docs/sphinx/conf.py : Add sphinx-codeautolink to extensions
* docs/sphinx/guide/getting-started.rst : Add some information such that
    imports are resolved correctly by the extension