### PR TITLE
Fix parsing remote refs

### DIFF
--- a/sphinx_polyversion/git.py
+++ b/sphinx_polyversion/git.py
@@ -64,7 +64,7 @@ async def _get_git_root(directory: Path) -> Path:
     return Path(out.decode().rstrip("\n"))
 
 
-regex_ref = r"refs/(?P<type>\w+|remotes/(?P<remote>[^/]+))/(?P<name>\S+)"
+regex_ref = r"refs/(?P<type>remotes/(?P<remote>[^/]+)|\w+)/(?P<name>\S+)"
 pattern_ref = re.compile(regex_ref)
 
 GIT_FORMAT_STRING = "%(objectname)\t%(refname)\t%(creatordate:iso)"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -14,6 +14,7 @@ from sphinx_polyversion.git import (
     Git,
     GitRef,
     GitRefType,
+    _parse_ref,
     closest_tag,
     file_exists,
     file_predicate,
@@ -327,3 +328,15 @@ async def test_file_predicate(git_testrepo: Tuple[Path, List[GitRef]]):
     assert len(refs) == 4
     for i in range(4):
         assert compare_refs(refs[i], git_refs[i + 1])
+
+
+def test_parse_remote_ref():
+    """Test that `_parse_ref` parses remote branch refs correctly."""
+    line = "0123456789abcdef\trefs/remotes/origin/feature\t2023-08-29 19:45:09 +0000"
+    ref = _parse_ref(line)
+    assert ref is not None
+    assert ref.name == "feature"
+    assert ref.remote == "origin"
+    assert ref.type_ == GitRefType.BRANCH
+    assert ref.obj == "0123456789abcdef"
+    assert ref.ref == "refs/remotes/origin/feature"


### PR DESCRIPTION
The regular expression for parsing refs output by `git for-each-ref` failed to recognize remote refs as the `|` operator matches from left to right and aborts as soon as it finds a match. The remote group however was given as second parameter and thus never matched. Thanks to @rzuckerm for reporting this issue and providing the fixed regex.

Fixes #44.

* sphinx_polyversion/git.py (regex_ref): Swap the order of the regex groups.
* tests/test_git.py (test_parse_refs): Test for this issue.