### PR TITLE
Add submodule support, switch to worktree method for checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ DefaultDriver(
     vcs=Git(
         branch_regex=BRANCH_REGEX,
         tag_regex=TAG_REGEX,
-        buffer_size=1 * 10**9,  # 1 GB
         predicate=file_predicate([src]), # exclude refs without source dir
     ),
     builder=SphinxBuilder(src / "sphinx", args=SPHINX_ARGS),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,6 +93,7 @@
 - [ ] Easy integration with ci
 - [ ] Github Action
 - [ ] Read conf file location from pyproject.toml?
+- [ ] uv support
 
 # Wishlist
 

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -79,7 +79,6 @@ DefaultDriver(
     vcs=Git(
         branch_regex=BRANCH_REGEX,
         tag_regex=TAG_REGEX,
-        buffer_size=1 * 10**9,  # 1 GB
         predicate=file_predicate([src]),  # exclude refs without source dir
     ),
     builder=SphinxBuilder(src / "sphinx", args=SPHINX_ARGS.split()),

--- a/docs/sphinx/guide/getting-started.rst
+++ b/docs/sphinx/guide/getting-started.rst
@@ -177,7 +177,6 @@ in its revision.
         vcs=Git(
             branch_regex=BRANCH_REGEX,
             tag_regex=TAG_REGEX,
-            buffer_size=1 * 10**9,  # 1 GB
             predicate=file_predicate([src]),  # exclude refs without source dir
         ),
         builder=SphinxBuilder(src / "sphinx", args=SPHINX_ARGS.split()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,3 +153,4 @@ addopts = [
     # "--numprocesses=auto",
 ]
 testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "function"

--- a/sphinx_polyversion/git.py
+++ b/sphinx_polyversion/git.py
@@ -6,8 +6,8 @@ import asyncio
 import enum
 import re
 import shutil
-import tarfile
 import tempfile
+import uuid
 from asyncio.subprocess import PIPE
 from datetime import datetime
 from functools import total_ordering
@@ -186,11 +186,42 @@ async def _get_all_refs(
             yield ref
 
 
-async def _copy_tree(
-    repo: Path, ref: str, dest: str | Path, buffer_size: int = 0
-) -> None:
+async def _init_submodules(repo: Path) -> None:
+    """
+    Initialize and update git submodules in the given repo.
+
+    This clones missing submodule repositories and checks out the commit
+    pinned by the current HEAD. Failures are logged but not raised, since
+    individual submodules may be unreachable while others succeed.
+
+    Parameters
+    ----------
+    repo : Path
+        The git repository.
+
+    """
+    logger.info("Initializing git submodules in %s", repo)
+    cmd = ("git", "submodule", "update", "--init", "--recursive")
+    process = await asyncio.create_subprocess_exec(
+        *cmd, cwd=repo, stdout=DEVNULL, stderr=PIPE
+    )
+    _, err = await process.communicate()
+    if process.returncode:
+        logger.warning(
+            "git submodule update --init failed in %s (rc=%d): %s",
+            repo,
+            process.returncode,
+            err.decode().strip() if err else "",
+        )
+
+
+async def _copy_tree(repo: Path, ref: str, dest: str | Path) -> None:
     """
     Copy the contents of a ref into a location in the file system.
+
+    Creates a temporary git worktree at the target ref and uses
+    ``git submodule update --init --recursive`` to let Git resolve
+    submodule URLs (including relative ones) natively.
 
     Parameters
     ----------
@@ -200,9 +231,6 @@ async def _copy_tree(
         The ref
     dest : Union[str, Path]
         The destination to copy the contents to
-    buffer_size : int
-        The buffer size in memory which is filled before
-        a temporary file is used for retrieving the contents. Defaults to 0.
 
     Raises
     ------
@@ -210,20 +238,53 @@ async def _copy_tree(
         The git process exited with an error.
 
     """
-    # retrieve commit contents as tar archive
-    # NOTE: doesn't support git submodules
-    cmd = ("git", "archive", "--format", "tar", ref)
-    with tempfile.SpooledTemporaryFile(max_size=buffer_size) as f:
-        process = await asyncio.create_subprocess_exec(
-            *cmd, cwd=repo, stdout=f, stderr=PIPE
+    with tempfile.TemporaryDirectory() as tmp:
+        wt_path = Path(tmp) / f"wt-{uuid.uuid4().hex}"
+
+        # Create a detached worktree at the target ref
+        cmd: tuple[str, ...] = (
+            "git",
+            "worktree",
+            "add",
+            "--detach",
+            str(wt_path),
+            ref,
         )
-        out, err = await process.communicate()
-        if process.returncode:
-            raise CalledProcessError(process.returncode, " ".join(cmd), stderr=err)
-        # extract tar archive to dir
-        f.seek(0)
-        with tarfile.open(fileobj=f) as tf:
-            tf.extractall(str(dest))
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, cwd=repo, stdout=DEVNULL, stderr=PIPE
+        )
+        _, err = await proc.communicate()
+        if proc.returncode:
+            raise CalledProcessError(proc.returncode, " ".join(cmd), stderr=err)
+
+        try:
+            # Let git initialize all submodules recursively
+            # (handles relative URLs via the superproject remote)
+            cmd = ("git", "submodule", "update", "--init", "--recursive")
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, cwd=wt_path, stdout=DEVNULL, stderr=PIPE
+            )
+            _, err = await proc.communicate()
+            if proc.returncode:
+                logger.warning(
+                    "git submodule update --init --recursive failed: %s",
+                    err.decode().strip() if err else "",
+                )
+
+            # Copy worktree contents to dest, excluding .git dirs
+            shutil.copytree(
+                wt_path,
+                dest,
+                ignore=shutil.ignore_patterns(".git"),
+                dirs_exist_ok=True,
+                symlinks=True,
+            )
+        finally:
+            rm_cmd = ("git", "worktree", "remove", "--force", str(wt_path))
+            proc = await asyncio.create_subprocess_exec(
+                *rm_cmd, cwd=repo, stdout=DEVNULL, stderr=DEVNULL
+            )
+            await proc.communicate()
 
 
 async def file_exists(repo: Path, ref: GitRef, file: PurePath) -> bool:
@@ -261,37 +322,133 @@ async def file_exists(repo: Path, ref: GitRef, file: PurePath) -> bool:
     return rc == 0
 
 
-async def _get_unignored_files(directory: Path) -> AsyncGenerator[Path, None]:
+async def _collect_ignored_for(root: Path) -> set[Path]:
     """
-    List all unignored files in the directory.
-
-    This uses git to retrieve all tracked and untracked files but excludes
-    files ignored e.g. by `.gitignore`.
+    Collect git-ignored paths for a single repository root.
 
     Parameters
     ----------
-    directory : Path
-        Any directory in the repo.
+    root : Path
+        The git repository or submodule root.
 
     Returns
     -------
-    AsyncGenerator[Path, None]
-        The paths to all un-ignored files in the directory (recursive)
+    set[Path]
+        Absolute paths of ignored files and directories.
 
     """
     cmd = (
         "git",
         "ls-files",
-        "--cached",
-        "--others",
+        "-z",
+        "--ignored",
         "--exclude-standard",
+        "--others",
+        "--directory",
+        "--no-empty-directory",
     )
-    process = await asyncio.create_subprocess_exec(*cmd, cwd=directory, stdout=PIPE)
-    while line := await process.stdout.readline():  # type: ignore[union-attr]
-        yield Path(line.strip().decode())
-    await process.wait()
-    if process.returncode:
-        raise CalledProcessError(process.returncode, " ".join(cmd))
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=root,
+        stdout=PIPE,
+        stderr=PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode:
+        raise CalledProcessError(proc.returncode, " ".join(cmd), stderr=err)
+    ignored: set[Path] = set()
+    if out:
+        for entry in out.decode().split("\0"):
+            if entry:
+                ignored.add(root / entry.rstrip("/"))
+    return ignored
+
+
+async def _get_submodule_paths(repo: Path) -> list[Path]:
+    """
+    Return paths of initialized submodules (recursive).
+
+    Parameters
+    ----------
+    repo : Path
+        The git repository.
+
+    Returns
+    -------
+    list[Path]
+        Absolute paths of initialized submodule directories.
+
+    """
+    cmd = ("git", "submodule", "status", "--recursive")
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=repo,
+        stdout=PIPE,
+        stderr=DEVNULL,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode:
+        raise CalledProcessError(proc.returncode, " ".join(cmd), stderr=err)
+    paths: list[Path] = []
+    if out:
+        for line in out.decode().splitlines():
+            # format: " <sha> <path> (<desc>)" or "-<sha> <path>" (not init'd)
+            parts = line.strip().split()
+            if len(parts) >= 2 and not parts[0].startswith("-"):  # noqa: PLR2004
+                sub_path = repo / parts[1]
+                if sub_path.is_dir():
+                    paths.append(sub_path)
+    return paths
+
+
+async def _collect_ignored(repo: Path) -> set[Path]:
+    """
+    Pre-compute all git-ignored paths for a repo and its submodules.
+
+    Returns absolute paths.  Directories are included (without trailing
+    slash) so that :func:`_make_copytree_filter` can prune them early.
+
+    Parameters
+    ----------
+    repo : Path
+        The git repository.
+
+    Returns
+    -------
+    set[Path]
+        Absolute paths of ignored files and directories.
+
+    """
+    ignored = await _collect_ignored_for(repo)
+    for sub_path in await _get_submodule_paths(repo):
+        ignored.update(await _collect_ignored_for(sub_path))
+
+    return ignored
+
+
+def _make_copytree_filter(
+    ignored: set[Path],
+) -> Callable[[str, list[str]], set[str]]:
+    """
+    Return an ignore callback for :func:`shutil.copytree`.
+
+    Parameters
+    ----------
+    ignored : set[Path]
+        Absolute paths of files/directories to skip.
+
+    Returns
+    -------
+    Callable[[str, list[str]], set[str]]
+        An ignore function suitable for ``shutil.copytree(ignore=...)``.
+
+    """
+
+    def ignore(directory: str, entries: list[str]) -> set[str]:
+        dir_path = Path(directory)
+        return {e for e in entries if e == ".git" or dir_path / e in ignored}
+
+    return ignore
 
 
 # -- VersionProvider API -----------------------------------------------------
@@ -436,10 +593,6 @@ class Git(VersionProvider[GitRef]):
     """
     Provide versions from git repository.
 
-    .. warning::
-
-        Currently git submodules aren't supported. Feel free to open an issue!
-
     Parameters
     ----------
     branch_regex : str | re.Pattern
@@ -458,12 +611,10 @@ class Git(VersionProvider[GitRef]):
         remote: str | None = None,
         *,
         predicate: Callable[[Path, GitRef], bool | Awaitable[bool]] | None = None,
-        buffer_size: int = 0,
     ) -> None:
         """Init."""
         super().__init__()
         self.remote = remote
-        self.buffer_size = buffer_size
 
         if isinstance(branch_regex, str):
             branch_regex = re.compile(branch_regex)
@@ -546,7 +697,7 @@ class Git(VersionProvider[GitRef]):
             The revision to extract.
 
         """
-        await _copy_tree(root, revision.obj, dest, self.buffer_size)
+        await _copy_tree(root, revision.obj, dest)
 
     async def checkout_local(self, root: Path, dest: Path) -> None:
         """
@@ -554,6 +705,10 @@ class Git(VersionProvider[GitRef]):
 
         This doesn't copy files ignored by `git` if possible.
         Otherwise all files are copied as a fallback.
+
+        .. warning::
+            This may alter the user's working tree
+            by calling ``git submodule update --init``.
 
         Parameters
         ----------
@@ -563,19 +718,23 @@ class Git(VersionProvider[GitRef]):
             The destination to extract the revision to.
 
         """
+        await _init_submodules(root)
         try:
-            # NOTE: doesn't support git submodules
-            async for file in _get_unignored_files(root):
-                source = root / file
-                target = dest / file
-                target.parent.mkdir(parents=True, exist_ok=True)
-                assert source.exists()
-                shutil.copy2(source, target, follow_symlinks=False)
+            ignored = await _collect_ignored(root)
         except CalledProcessError:
             logger.warning(
-                "Could not list un-ignored files using git. Copying full working directory..."
+                "Could not determine ignored files using git. "
+                "Copying full working directory..."
             )
             shutil.copytree(root, dest, symlinks=True, dirs_exist_ok=True)
+            return
+        shutil.copytree(
+            root,
+            dest,
+            ignore=_make_copytree_filter(ignored),
+            symlinks=True,
+            dirs_exist_ok=True,
+        )
 
     async def predicate(self, root: Path, ref: GitRef) -> bool:
         """

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import shutil
 import subprocess
+from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
-from typing import List, Mapping, Tuple
+from typing import Any, Awaitable, Callable, List, Mapping, NamedTuple, Tuple
 
 import pytest
+import pytest_asyncio
 
 from sphinx_polyversion.git import (
     Git,
@@ -79,21 +83,33 @@ def no_git_env(_env: Mapping[str, str] | None = None) -> dict[str, str]:
     }
 
 
-@pytest.fixture
-def git_testrepo(tmp_path: Path) -> Tuple[Path, List[GitRef]]:
+@pytest_asyncio.fixture
+async def git_testrepo(tmp_path: Path) -> Tuple[Path, List[GitRef]]:
     """Create a git repository for testing."""
-    git = ("git", *NO_FS_MONITOR)
     env = no_git_env()
 
-    def run_git(*args: str) -> None:
-        subprocess.run(git + args, cwd=tmp_path, env=env, check=False)
+    async def run_git(*args: str, capture: bool = False) -> str:
+        cmd = ("git", *NO_FS_MONITOR, *args)
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=tmp_path,
+            env=env,
+            stdout=subprocess.PIPE if capture else None,
+            stderr=subprocess.PIPE,
+        )
+        out, err = await process.communicate()
+        if process.returncode:
+            raise subprocess.CalledProcessError(
+                process.returncode, " ".join(cmd), stderr=err
+            )
+        return out.decode() if out else ""
 
     # init repo
-    run_git("init")
-    run_git("config", "user.email", "example@example.com")
-    run_git("config", "user.name", "example")
-    run_git("config", "commit.gpgsign", "false")
-    run_git("config", "init.defaultBranch", "main")
+    await run_git("init")
+    await run_git("config", "user.email", "example@example.com")
+    await run_git("config", "user.name", "example")
+    await run_git("config", "commit.gpgsign", "false")
+    await run_git("config", "init.defaultBranch", "main")
 
     # create some files and directories to commit
     tmp_path.joinpath("test.txt").write_text("test")
@@ -102,11 +118,11 @@ def git_testrepo(tmp_path: Path) -> Tuple[Path, List[GitRef]]:
     tmp_path.joinpath("dir1", "file1.txt").write_text("file1")
     tmp_path.joinpath("dir2", "file3.txt").write_text("file3")
 
-    run_git("add", ".")
-    run_git("commit", "-m", "test")
+    await run_git("add", ".")
+    await run_git("commit", "-m", "test")
 
     # create a branch
-    run_git("branch", "dev")
+    await run_git("branch", "dev")
 
     # create changes to commit
     tmp_path.joinpath("test.txt").write_text("test2")
@@ -114,31 +130,28 @@ def git_testrepo(tmp_path: Path) -> Tuple[Path, List[GitRef]]:
     tmp_path.joinpath("dir1", "file1.txt").write_text("file1a")
     tmp_path.joinpath("dir2", "file3.txt").write_text("file3a")
 
-    run_git("add", ".")
-    run_git("commit", "-m", "test2")
+    await run_git("add", ".")
+    await run_git("commit", "-m", "test2")
 
     # create a tag
-    run_git("tag", "1.0", "-m", "")
+    await run_git("tag", "1.0", "-m", "")
 
     # commit some more changes
     tmp_path.joinpath("test.txt").write_text("test3")
     tmp_path.joinpath("dir1", "file2.txt").write_text("file2a")
     tmp_path.joinpath("dir1", "file1.txt").write_text("file1b")
 
-    run_git("add", ".")
-    run_git("commit", "-m", "test3")
+    await run_git("add", ".")
+    await run_git("commit", "-m", "test3")
 
     # create another branch
-    run_git("branch", "feature")
+    await run_git("branch", "feature")
 
     # tag the latest commit
-    run_git("tag", "2.0", "-m", "")
+    await run_git("tag", "2.0", "-m", "")
 
-    p = subprocess.run(
-        ["git", "for-each-ref", "--format=%(objectname) %(refname)"],
-        cwd=tmp_path,
-        stdout=subprocess.PIPE,
-        check=False,
+    p_out = await run_git(
+        "for-each-ref", "--format=%(objectname) %(refname)", capture=True
     )
 
     types = [
@@ -155,7 +168,7 @@ def git_testrepo(tmp_path: Path) -> Tuple[Path, List[GitRef]]:
         datetime(2023, 6, 29, 11, 43, 11),
         datetime(2023, 8, 29, 19, 45, 9),
     ]
-    lines = [line.split() for line in p.stdout.decode().splitlines()]
+    lines = [line.split() for line in p_out.splitlines()]
     refs = [
         GitRef(r.split("/")[-1], h, r, t, d)
         for t, (h, r), d in zip(types, lines, dates)
@@ -183,12 +196,6 @@ def git_with_predicate() -> Git:
     )
 
 
-@pytest.fixture
-def git_with_buffer_size() -> Git:
-    """Create a `Git` instance with a buffer size for testing."""
-    return Git(branch_regex=".*", tag_regex=".*", buffer_size=1024)
-
-
 @pytest.mark.asyncio
 async def test_aroot(git: Git, git_testrepo: Tuple[Path, List[GitRef]]):
     """Test the `aroot` method."""
@@ -209,18 +216,6 @@ async def test_checkout(
     """Test the `checkout` method."""
     repo_path, refs = git_testrepo
     await git.checkout(repo_path, tmp_path, refs[0])
-    assert (tmp_path / "test.txt").read_text() == "test"
-
-
-@pytest.mark.asyncio
-async def test_checkout_with_buffer(
-    git_with_buffer_size: Git,
-    git_testrepo: Tuple[Path, List[GitRef]],
-    tmp_path: Path,
-):
-    """Test the `checkout` method."""
-    repo_path, refs = git_testrepo
-    await git_with_buffer_size.checkout(repo_path, tmp_path, refs[0])
     assert (tmp_path / "test.txt").read_text() == "test"
 
 
@@ -340,3 +335,453 @@ def test_parse_remote_ref():
     assert ref.type_ == GitRefType.BRANCH
     assert ref.obj == "0123456789abcdef"
     assert ref.ref == "refs/remotes/origin/feature"
+
+
+# --- Submodule tests ---------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _allow_file_protocol(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Allow local file:// submodule URLs for all tests in this module.
+
+    ``git submodule update --init --recursive`` spawns nested ``git clone``
+    processes that do not inherit the parent repo's config.
+    ``GIT_ALLOW_PROTOCOL`` is propagated through all child processes.
+    """
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file:https:ssh:git")
+
+
+async def _run_git(
+    cwd: Path,
+    *args: str,
+    env_add: Mapping[str, str] | None = None,
+    capture: bool = False,
+) -> str:
+    git = ("git", *NO_FS_MONITOR, *args)
+    env = no_git_env()
+    if env_add:
+        env.update(env_add)
+    proc = await asyncio.create_subprocess_exec(
+        *git,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, " ".join(git), stderr=err)
+    return out.decode() if out else ""
+
+
+class SubmoduleRepo(NamedTuple):
+    """Container for the `git_submodule_repo` fixture."""
+
+    main: Path
+    make_fetch_needed: Callable[[], Awaitable[None]]
+
+
+@pytest_asyncio.fixture
+async def git_submodule_repo(tmp_path: Path) -> SubmoduleRepo:
+    """
+    Create a git repository with a submodule and provide a hook to force a fetch-needed state.
+
+    Layout:
+      tmp/subrepo            # standalone repo
+      tmp/main               # includes subrepo as submodule at third_party/sub
+
+    Initially, main pins submodule at v1; subrepo then advances to v2.
+    The returned hook replaces the submodule working tree with a shallow clone
+    (v2 only) and recreates staged/untracked files so that checkout requires fetching v1.
+    """
+    # Create subrepo with initial commit (v1)
+    subrepo = tmp_path / "subrepo"
+    subrepo.mkdir()
+    await _run_git(subrepo, "init")
+    await _run_git(subrepo, "config", "user.email", "example@example.com")
+    await _run_git(subrepo, "config", "user.name", "example")
+    await _run_git(subrepo, "config", "commit.gpgsign", "false")
+    (subrepo / "lib.txt").write_text("sub v1")
+    (subrepo / "committed1.txt").write_text("c1 v1")
+    (subrepo / "committed2.txt").write_text("c2 v1")
+    await _run_git(subrepo, "add", ".")
+    await _run_git(subrepo, "commit", "-m", "sub v1")
+
+    # Create main with submodule pinned at v1
+    mainrepo = tmp_path / "main"
+    mainrepo.mkdir()
+    await _run_git(mainrepo, "init")
+    await _run_git(mainrepo, "config", "user.email", "example@example.com")
+    await _run_git(mainrepo, "config", "user.name", "example")
+    await _run_git(mainrepo, "config", "commit.gpgsign", "false")
+    await _run_git(mainrepo, "config", "protocol.file.allow", "always")
+    (mainrepo / "root.txt").write_text("root")
+    await _run_git(mainrepo, "add", ".")
+    await _run_git(mainrepo, "commit", "-m", "root")
+
+    await _run_git(
+        mainrepo,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        subrepo.as_posix(),
+        "third_party/sub",
+        env_add={"GIT_ALLOW_PROTOCOL": "file"},
+    )
+    await _run_git(mainrepo, "commit", "-m", "add submodule at v1")
+
+    # Advance subrepo to v2 (HEAD)
+    (subrepo / "lib.txt").write_text("sub v2")
+    await _run_git(subrepo, "add", ".")
+    await _run_git(subrepo, "commit", "-m", "sub v2")
+
+    # staged & untracked files in the submodule working copy
+    sub_path = mainrepo / "third_party" / "sub"
+    (sub_path / "staged1.txt").write_text("s1")
+    (sub_path / "staged2.txt").write_text("s2")
+    await _run_git(sub_path, "add", "staged1.txt", "staged2.txt")
+    (sub_path / "untracked1.txt").write_text("u1")
+    (sub_path / "untracked2.txt").write_text("u2")
+
+    async def make_fetch_needed() -> None:
+        # Replace submodule working tree with shallow clone that has only v2
+        shutil.rmtree(sub_path)
+        await _run_git(
+            mainrepo,
+            "-c",
+            "protocol.file.allow=always",
+            "clone",
+            "--depth=1",
+            subrepo.as_posix(),
+            "third_party/sub",
+            env_add={"GIT_ALLOW_PROTOCOL": "file"},
+        )
+        await _run_git(sub_path, "config", "protocol.file.allow", "always")
+        # recreate staged/untracked in the shallow clone
+        (sub_path / "staged1.txt").write_text("s1")
+        (sub_path / "staged2.txt").write_text("s2")
+        await _run_git(sub_path, "add", "staged1.txt", "staged2.txt")
+        (sub_path / "untracked1.txt").write_text("u1")
+        (sub_path / "untracked2.txt").write_text("u2")
+
+    return SubmoduleRepo(mainrepo, make_fetch_needed)
+
+
+@pytest.mark.asyncio
+async def test_checkout_with_submodules(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout` should copy pinned submodule contents recursively."""
+    mainrepo = git_submodule_repo.main
+
+    # Resolve current HEAD of the main repo to build the GitRef
+    head = (await _run_git(mainrepo, "rev-parse", "HEAD", capture=True)).strip()
+    ref = GitRef("HEAD", head, "HEAD", GitRefType.BRANCH, datetime.now())
+
+    await git.checkout(mainrepo, tmp_path, ref)
+
+    # Root files should be present
+    assert (tmp_path / "root.txt").exists()
+    assert (tmp_path / ".gitmodules").exists()
+
+    # Submodule file should be copied at the pinned commit (v1)
+    for name, content in (
+        ("lib.txt", "sub v1"),
+        ("committed1.txt", "c1 v1"),
+        ("committed2.txt", "c2 v1"),
+    ):
+        p = tmp_path / "third_party" / "sub" / name
+        assert p.exists()
+        assert p.read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_checkout_local_with_submodules(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout_local` should include files from initialized submodules."""
+    mainrepo = git_submodule_repo.main
+
+    await git.checkout_local(mainrepo, tmp_path)
+
+    # Submodule working copy in main repo is at v1, ensure it gets copied
+    for name, content in (
+        ("lib.txt", "sub v1"),
+        ("committed1.txt", "c1 v1"),
+        ("committed2.txt", "c2 v1"),
+    ):
+        p = tmp_path / "third_party" / "sub" / name
+        assert p.exists()
+        assert p.read_text() == content
+
+    # staged files should be copied as they are in the index
+    for name in ("staged1.txt", "staged2.txt"):
+        p = tmp_path / "third_party" / "sub" / name
+        assert p.exists()
+        assert p.read_text() in {"s1", "s2"}
+
+    # Untracked files from submodule should also be copied
+    for name, content in (("untracked1.txt", "u1"), ("untracked2.txt", "u2")):
+        copied_untracked = tmp_path / "third_party" / "sub" / name
+        assert copied_untracked.exists()
+        assert copied_untracked.read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_checkout_with_submodules_fetch(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout` should fetch missing submodule commits and copy pinned state."""
+    mainrepo = git_submodule_repo.main
+    await git_submodule_repo.make_fetch_needed()
+    head = (await _run_git(mainrepo, "rev-parse", "HEAD", capture=True)).strip()
+    ref = GitRef("HEAD", head, "HEAD", GitRefType.BRANCH, datetime.now())
+
+    await git.checkout(mainrepo, tmp_path, ref)
+
+    # Pinned content from v1 should be fetched and used
+    for name, content in (
+        ("lib.txt", "sub v1"),
+        ("committed1.txt", "c1 v1"),
+        ("committed2.txt", "c2 v1"),
+    ):
+        p = tmp_path / "third_party" / "sub" / name
+        assert p.exists()
+        assert p.read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_checkout_clones_removed_submodule(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout` of an old ref should clone a submodule removed from HEAD."""
+    mainrepo = git_submodule_repo.main
+
+    # Record the commit that still has the submodule
+    old_head = (await _run_git(mainrepo, "rev-parse", "HEAD", capture=True)).strip()
+
+    # Remove the submodule from HEAD
+    await _run_git(mainrepo, "submodule", "deinit", "-f", "--", "third_party/sub")
+    await _run_git(mainrepo, "rm", "-f", "third_party/sub")
+    shutil.rmtree(mainrepo / ".git" / "modules" / "third_party", ignore_errors=True)
+    await _run_git(mainrepo, "commit", "-m", "remove submodule")
+
+    # Checkout the OLD commit that still had the submodule
+    ref = GitRef("old", old_head, "old", GitRefType.BRANCH, datetime.now())
+    await git.checkout(mainrepo, tmp_path, ref)
+
+    # Root files and submodule content from the old commit should be present
+    assert (tmp_path / "root.txt").exists()
+    for name, content in (
+        ("lib.txt", "sub v1"),
+        ("committed1.txt", "c1 v1"),
+        ("committed2.txt", "c2 v1"),
+    ):
+        p = tmp_path / "third_party" / "sub" / name
+        assert p.exists()
+        assert p.read_text() == content
+
+    # The source repo's working tree must NOT be modified
+    assert not (mainrepo / "third_party" / "sub").exists()
+
+
+@pytest.mark.asyncio
+async def test_checkout_recovers_deinitialized_submodule(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout` should re-initialize a deinit'd submodule via `update --init`."""
+    mainrepo = git_submodule_repo.main
+    with suppress(subprocess.CalledProcessError):
+        await _run_git(mainrepo, "submodule", "deinit", "-f", "--", "third_party/sub")
+
+    head = (await _run_git(mainrepo, "rev-parse", "HEAD", capture=True)).strip()
+    ref = GitRef("HEAD", head, "HEAD", GitRefType.BRANCH, datetime.now())
+
+    await git.checkout(mainrepo, tmp_path, ref)
+
+    # update --init recovers the submodule; content should be present
+    assert (tmp_path / "root.txt").exists()
+    for name, content in (
+        ("lib.txt", "sub v1"),
+        ("committed1.txt", "c1 v1"),
+        ("committed2.txt", "c2 v1"),
+    ):
+        p = tmp_path / "third_party" / "sub" / name
+        assert p.exists()
+        assert p.read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_checkout_skips_unavailable_submodule(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout` should skip a submodule whose remote is unreachable."""
+    mainrepo = git_submodule_repo.main
+    # Deinitialize, remove git object store, and remove the remote repo
+    # so neither update --init nor clone can recover
+    with suppress(subprocess.CalledProcessError):
+        await _run_git(mainrepo, "submodule", "deinit", "-f", "--", "third_party/sub")
+    shutil.rmtree(mainrepo / ".git" / "modules" / "third_party", ignore_errors=True)
+    shutil.rmtree(tmp_path / "subrepo", ignore_errors=True)
+
+    head = (await _run_git(mainrepo, "rev-parse", "HEAD", capture=True)).strip()
+    ref = GitRef("HEAD", head, "HEAD", GitRefType.BRANCH, datetime.now())
+
+    await git.checkout(mainrepo, tmp_path, ref)
+
+    # Root files copied, submodule gracefully skipped
+    assert (tmp_path / "root.txt").exists()
+    for name in ("lib.txt", "committed1.txt", "committed2.txt"):
+        assert not (tmp_path / "third_party" / "sub" / name).exists()
+
+
+@pytest.mark.asyncio
+async def test_checkout_local_recovers_deinitialized_submodule(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout_local` should re-initialize a deinit'd submodule."""
+    mainrepo = git_submodule_repo.main
+    with suppress(subprocess.CalledProcessError):
+        await _run_git(mainrepo, "submodule", "deinit", "-f", "--", "third_party/sub")
+    shutil.rmtree(mainrepo / "third_party" / "sub", ignore_errors=True)
+
+    await git.checkout_local(mainrepo, tmp_path)
+
+    # update --init recovers the submodule; committed files should be present
+    assert (tmp_path / "root.txt").exists()
+    for name, content in (
+        ("lib.txt", "sub v1"),
+        ("committed1.txt", "c1 v1"),
+        ("committed2.txt", "c2 v1"),
+    ):
+        p = tmp_path / "third_party" / "sub" / name
+        assert p.exists()
+        assert p.read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_checkout_local_skips_unavailable_submodule(
+    git: Git, git_submodule_repo: SubmoduleRepo, tmp_path: Path
+):
+    """`checkout_local` should skip a submodule whose remote is unreachable."""
+    mainrepo = git_submodule_repo.main
+    with suppress(subprocess.CalledProcessError):
+        await _run_git(mainrepo, "submodule", "deinit", "-f", "--", "third_party/sub")
+    shutil.rmtree(mainrepo / ".git" / "modules" / "third_party", ignore_errors=True)
+    shutil.rmtree(mainrepo / "third_party" / "sub", ignore_errors=True)
+    shutil.rmtree(tmp_path / "subrepo", ignore_errors=True)
+
+    await git.checkout_local(mainrepo, tmp_path)
+
+    assert (tmp_path / "root.txt").exists()
+    for name in (
+        "lib.txt",
+        "committed1.txt",
+        "committed2.txt",
+    ):
+        assert not (tmp_path / "third_party" / "sub" / name).exists()
+
+
+# --- Nested submodule tests --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_checkout_with_nested_submodules(git: Git, tmp_path: Path):
+    """`checkout` should recurse into nested submodules (sub within sub)."""
+
+    async def rg(cwd: Path, *args: str, **kwargs: Any) -> str:
+        return await _run_git(cwd, *args, **kwargs, capture=True)
+
+    async def rg_void(cwd: Path, *args: str, **kwargs: Any) -> None:
+        await _run_git(cwd, *args, **kwargs)
+
+    # Create innermost repo (leaf)
+    leaf = tmp_path / "leaf"
+    leaf.mkdir()
+    await rg_void(leaf, "init")
+    await rg_void(leaf, "config", "user.email", "e@e.com")
+    await rg_void(leaf, "config", "user.name", "e")
+    await rg_void(leaf, "config", "commit.gpgsign", "false")
+    (leaf / "leaf.txt").write_text("leaf content")
+    await rg_void(leaf, "add", ".")
+    await rg_void(leaf, "commit", "-m", "leaf")
+
+    # Create middle repo with leaf as submodule
+    middle = tmp_path / "middle"
+    middle.mkdir()
+    await rg_void(middle, "init")
+    await rg_void(middle, "config", "user.email", "e@e.com")
+    await rg_void(middle, "config", "user.name", "e")
+    await rg_void(middle, "config", "commit.gpgsign", "false")
+    await rg_void(middle, "config", "protocol.file.allow", "always")
+    (middle / "mid.txt").write_text("mid content")
+    await rg_void(middle, "add", ".")
+    await rg_void(middle, "commit", "-m", "mid")
+    await rg_void(
+        middle,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        leaf.as_posix(),
+        "deps/leaf",
+        env_add={"GIT_ALLOW_PROTOCOL": "file"},
+    )
+    await rg_void(middle, "commit", "-m", "add leaf submodule")
+
+    # Create outer repo with middle as submodule
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    await rg_void(outer, "init")
+    await rg_void(outer, "config", "user.email", "e@e.com")
+    await rg_void(outer, "config", "user.name", "e")
+    await rg_void(outer, "config", "commit.gpgsign", "false")
+    await rg_void(outer, "config", "protocol.file.allow", "always")
+    (outer / "root.txt").write_text("outer content")
+    await rg_void(outer, "add", ".")
+    await rg_void(outer, "commit", "-m", "outer")
+    await rg_void(
+        outer,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        middle.as_posix(),
+        "vendor/mid",
+        env_add={"GIT_ALLOW_PROTOCOL": "file"},
+    )
+    await rg_void(outer, "commit", "-m", "add middle submodule")
+
+    # Pre-initialize the nested leaf submodule inside middle's working copy.
+    # In tests, git clone blocks file:// transport unless the spawning repo
+    # has protocol.file.allow=always, but `git submodule update --init` spawns
+    # a clone subprocess that doesn't inherit the parent's local config.
+    # Pre-initializing here avoids this test-only issue.
+    mid_in_outer = outer / "vendor" / "mid"
+    await rg_void(mid_in_outer, "config", "protocol.file.allow", "always")
+    await rg_void(
+        mid_in_outer,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "update",
+        "--init",
+        env_add={"GIT_ALLOW_PROTOCOL": "file"},
+    )
+
+    # Checkout into a fresh destination
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    head = (await rg(outer, "rev-parse", "HEAD")).strip()
+    ref = GitRef("HEAD", head, "HEAD", GitRefType.BRANCH, datetime.now())
+
+    await git.checkout(outer, dest, ref)
+
+    # Verify all three levels
+    assert (dest / "root.txt").read_text() == "outer content"
+    assert (dest / "vendor" / "mid" / "mid.txt").read_text() == "mid content"
+    assert (
+        dest / "vendor" / "mid" / "deps" / "leaf" / "leaf.txt"
+    ).read_text() == "leaf content"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 """Test the `utils` submodule."""
 
-import asyncio
 from pathlib import Path, PurePath
 from typing import TypeVar
 
@@ -28,25 +27,26 @@ def test_shift_path(anchor1, anchor2, path, solution):
 T = TypeVar("T")
 
 
-def test_async_all():
+@pytest.mark.asyncio
+async def test_async_all():
     """Test the `async_all` implementation."""
 
     async def future(value: T) -> T:
         return value
 
-    assert asyncio.run(async_all([]))
+    assert await async_all([])
 
     all_true = [future(True) for i in range(8)]
-    assert asyncio.run(async_all(all_true))
+    assert await async_all(all_true)
 
     all_false = [future(False) for i in range(8)]
-    assert not asyncio.run(async_all(all_false))
+    assert not await async_all(all_false)
 
     first_false = [future(False)] + [future(True) for i in range(8)]
-    assert not asyncio.run(async_all(first_false))
+    assert not await async_all(first_false)
 
     last_false = [future(True) for i in range(8)] + [future(False)]
-    assert not asyncio.run(async_all(last_false))
+    assert not await async_all(last_false)
 
     some_false = (
         [future(True) for i in range(5)]
@@ -55,7 +55,7 @@ def test_async_all():
         + [future(False)]
         + [future(True) for i in range(5)]
     )
-    assert not asyncio.run(async_all(some_false))
+    assert not await async_all(some_false)
 
 
 def test_import_file(tmp_path: Path):


### PR DESCRIPTION
Instead of using `
git archive` to manually
copy files involving all kinds of extra logic
(e.g. especially for submodules), a completely new approach is taken.
`
Git.checkout` now calls 
`
git worktree add --detach` to create a
temporary linked worktree, copy its contents with 
`
shutil.copytree`
and then removing the linked worktree again. This lets Git handle
all the complexities improving maintainability of the code base.
Calling 
`
git submodule update --init --recursive` in the linked worktree
gives native support for submodules - almost for free.

The 
`
checkout_local` method is also rewritten to support submodules.
It now involves a single call to 
`
shutil.copytree` with a ignore
filter produced from a pre-computed list of git-ignored paths
from 
`
git ls-files --ignored --directory ...`.

This commit makes the Git support significantly more robust alongside
easy support for submodules.

This breaks some stuff:
The 
`
buffer_size` parameter is removed from 
`
Git`.
A side effect is added to 
`
Git.checkout_local`
since it now intializes and updates submodules.

Fixes https://github.com/real-yfprojects/sphinx-polyversion/issues/43.

* README.md: Remove `
buffer_size` from docs.
* docs/poly.py: Remove 
`
buffer_size`.
* docs/sphinx/guide/getting-started.rst: Remove 
`
buffer_size` from docs.
* sphinx_polyversion/git.py (_init_submodules): New function. Initialize git submodules in a repository.
* sphinx_polyversion/git.py (_copy_tree): Rewrite. Use a temporary detached worktree at the target ref with git submodule update --init --recursive instead of git archive, so Git resolves all submodule URLs natively. Remove buffer_size parameter.
* sphinx_polyversion/git.py (_collect_ignored): New function. Pre-compute all git-ignored paths for a repo and its submodules using git ls-files --ignored --directory in a single pass per repo level.
* sphinx_polyversion/git.py (_make_copytree_filter): New function. Return a shutil.copytree ignore callback that performs pure set lookups against the pre-computed ignored paths.
* sphinx_polyversion/git.py (Git.init): Remove buffer_size parameter, no longer used.
* sphinx_polyversion/git.py (Git.checkout): Call the rewritten _copy_tree.
* sphinx_polyversion/git.py (Git.checkout_local): Rewrite. Initialize submodules, collect ignored paths, then copy the working tree with shutil.copytree and the ignore filter.
* tests/test_git.py (_allow_file_protocol): New autouse fixture. Set GIT_ALLOW_PROTOCOL so nested child processes spawned by git submodule update can clone local file:// URLs in tests.
* tests/test_git.py: Add tests for submodule extraction, fetch of missing submodule commits, deinitialized and unavailable submodules, nested submodules, and local checkout with submodules. Convert remaining fixtures to async.
* pyproject.toml: Set asyncio_default_fixture_loop_scope to silence pytest-asyncio deprecation warning.